### PR TITLE
Address SME review

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -33,8 +33,8 @@ Explore how to use GraphQL to access and manipulate data using MicroProfile Grap
 You will learn how to build and test a simple GraphQL service with MicroProfile GraphQL. 
 
 GraphQL is an open source data query and manipulation language. 
-Unlike REST APIs, `POST` requests going to a GraphQL service all go to a single endpoint.
-Operations and their details are differentiated by the contents of the `POST` request.
+Unlike REST APIs, `POST` requests going to a GraphQL service all go to a single HTTP endpoint.
+Operations and their details are differentiated by the contents of the request.
 If the operation returns data, the user will also specify what properties of the data they want returned. 
 A JSON object is returned that contains only the data and properties specified.
 
@@ -45,14 +45,14 @@ GraphQL reduces processing time by only calculating them if requested.
 
 You can learn more about GraphQL at the https://graphql.org/[GraphQL website^].
 
-The service you'll create will respond to `POST` requests made to the `\http://localhost:9080/graphql` URL. 
+The service you'll create will respond to requests made to the `\http://localhost:9080/graphql` URL. 
 The operations you'll implement will be a simple `query` operation and a `mutation` operation.
 The `query` operation will return system information.
 The `mutation` operation will save a note of your choice into the system information. 
 
 Manual testing of the application will be done using https://github.com/graphql/graphiql/tree/main/packages/graphiql[GraphiQL^], which is included in the project.
-GraphiQL is a webpage that allows you to easily make `POST` requests to the GraphQL service and see the responses.
-In GraphiQL you only need to type the body of the `POST` request, streamlining manual tests. 
+GraphiQL is a webpage that allows you to easily make requests to the GraphQL service and see the responses.
+In GraphiQL you only need to type the body of the request, streamlining manual tests. 
 You're also able to view a history of your previous requests and repeat any of them.
 
 ///////////////////////////
@@ -256,7 +256,7 @@ include::{common-includes}/devmode-build.adoc[]
 
 GraphiQL has already been set up and included for you.
 Access GraphiQL at the http://localhost:9080/graphiql.html[^] URL.
-Queries made through GraphiQL will be the same as queries made through `POST` requests. 
+Queries made through GraphiQL will be the same as queries made through HTTP requests. 
 
 In GraphiQL, you can view the application documentation by clicking `Docs`. 
 The documentation will describe the GraphQL schema.

--- a/README.adoc
+++ b/README.adoc
@@ -121,7 +121,10 @@ The `java` object type will give information on the system's Java installation.
 The [hotspot=description file=0]`@Description` annotation gives a description to the `java` object type in GraphQL.
 This description is what will appear in the schema and the documentation. 
 
-The [hotspot=name1 hotspot=name2 file=0]`@Name` annotations map their respective properties to properties of the `java` object type in GraphQL. 
+The [hotspot=name file=0]`@Name` annotation maps the `vendor` property to the `vendorName` property of the `java` object type in GraphQL. 
+The [hotspot=name file=0]`@Name` annotation is used when mapping a property in a Java object to a property of a different name in the GraphQL object type.
+Without an [hotspot=name file=0]`@Name` annotation the Java object property will be automatically mapped to a GraphQL object type property of the same name. 
+
 All data types in GraphQL are nullable by default.
 Non-nullable properties are annotated with the [hotspot=nonnull file=0]`@NonNull` annotation.
 The [hotspot=getVendor file=0]`getVendor()` and [hotspot=getVersion file=0]`getVersion()` getter functions will automatically be mapped to retrieve their respective properties in GraphQL. 

--- a/README.adoc
+++ b/README.adoc
@@ -9,7 +9,7 @@
 :projectid: graphql-intro
 :page-layout: guide-multipane
 :page-duration: 25 minutes
-:page-releasedate: 2021-01-29
+:page-releasedate: 2021-02-28
 :page-essential: false
 :page-description: Learn how to create and test a GraphQL service using MicroProfile GraphQL and Open Liberty.
 :page-tags: ['MicroProfile', 'Java EE', 'Jakarta EE']

--- a/README.adoc
+++ b/README.adoc
@@ -120,6 +120,7 @@ The `java` object type will give information on the system's Java installation.
 
 The [hotspot=description file=0]`@Description` annotation gives a description to the `java` object type in GraphQL.
 This description is what will appear in the schema and the documentation. 
+Descriptions aren't required, but it's good practice to include them. 
 
 The [hotspot=name file=0]`@Name` annotation maps the `vendor` property to the `vendorName` property of the `java` object type in GraphQL. 
 The [hotspot=name file=0]`@Name` annotation is used when mapping a property in a Java object to a property of a different name in the GraphQL object type.
@@ -198,6 +199,7 @@ The [hotspot=editNoteHeader file=0]`@Name` annotation in this context denotes wh
 Here, there's just one input `note` for the note to write into the system properties.
 
 Each resolver function has an [hotspot=description1 hotspot=description2 file=0]`@Description` annotation, which provides a description to be used for the schema. 
+Descriptions aren't required, but it's good practice to include. 
 
 The [hotspot=operatingSystemHeader hotspot=javaHeader file=0]`@Source` annotation is used to add properties to object types. 
 Here the [hotspot=operatingSystemHeader hotspot=javaHeader file=0]`@Source` annotation adds [hotspot=javaFunction file=0]`java` 

--- a/README.adoc
+++ b/README.adoc
@@ -129,7 +129,8 @@ mapped to a GraphQL object type property of the same name.
 
 All data types in GraphQL are nullable by default.
 Non-nullable properties are annotated with the [hotspot=nonnull file=0]`@NonNull` annotation.
-The [hotspot=getVendor file=0]`getVendor()` and [hotspot=getVersion file=0]`getVersion()` getter functions will automatically be mapped to retrieve their respective properties in GraphQL. 
+The [hotspot=getVendor file=0]`getVendor()` and [hotspot=getVersion file=0]`getVersion()` getter functions 
+will automatically be mapped to retrieve their respective properties in GraphQL. 
 If needed, setter functions are also supported and will be automatically mapped. 
 
 [role="code_command hotspot file=1" ,subs="quotes"]

--- a/README.adoc
+++ b/README.adoc
@@ -124,7 +124,8 @@ Descriptions aren't required, but it's good practice to include them.
 
 The [hotspot=name file=0]`@Name` annotation maps the `vendor` property to the `vendorName` property of the `java` object type in GraphQL. 
 The [hotspot=name file=0]`@Name` annotation is used when mapping a property in a Java object to a property of a different name in the GraphQL object type.
-Without an [hotspot=name file=0]`@Name` annotation the Java object property will be automatically mapped to a GraphQL object type property of the same name. 
+Without an [hotspot=name file=0]`@Name` annotation, the Java object property will be automatically 
+mapped to a GraphQL object type property of the same name. 
 
 All data types in GraphQL are nullable by default.
 Non-nullable properties are annotated with the [hotspot=nonnull file=0]`@NonNull` annotation.

--- a/README.adoc
+++ b/README.adoc
@@ -12,7 +12,7 @@
 :page-releasedate: 2021-02-28
 :page-essential: false
 :page-description: Learn how to create and test a GraphQL service using MicroProfile GraphQL and Open Liberty.
-:page-tags: ['MicroProfile', 'Java EE', 'Jakarta EE']
+:page-tags: ['MicroProfile', 'Jakarta EE']
 :page-related-guides: ['rest-intro', 'jpa-intro', 'mongodb-intro']
 :page-permalink: /guides/{projectid}
 :common-includes: https://raw.githubusercontent.com/OpenLiberty/guides-common/master

--- a/README.adoc
+++ b/README.adoc
@@ -286,12 +286,12 @@ The output will be similar to the following:
   "data": {
     "system": {
       "java": {
-        "vendor": "Oracle Corporation",
-        "version": "11.0.7"
+        "vendor": "N/A",
+        "version": "13.0.2"
       },
       "operatingSystem": {
         "arch": "x86_64",
-        "version": "10.15.6",
+        "version": "10.15.7",
         "name": "Mac OS X"
       },
       "username": "admin",

--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>3.3</version>
+            <version>4.0.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>

--- a/finish/src/main/java/io/openliberty/guides/graphql/models/JavaInfo.java
+++ b/finish/src/main/java/io/openliberty/guides/graphql/models/JavaInfo.java
@@ -38,7 +38,7 @@ public class JavaInfo {
     // end::nonnull[]
     private String version;
 
-    public JavaInfo(Properties systemProperties) {
+    public JavaInfo(final Properties systemProperties) {
         this.version = systemProperties.getProperty("java.version");
         this.vendor = systemProperties.getProperty("java.vendor");
     }

--- a/finish/src/main/java/io/openliberty/guides/graphql/models/JavaInfo.java
+++ b/finish/src/main/java/io/openliberty/guides/graphql/models/JavaInfo.java
@@ -28,17 +28,14 @@ import org.eclipse.microprofile.graphql.Type;
 // tag::class[]
 public class JavaInfo {
 
-    // tag::name1[]
-    @Name("vendor")
-    // end::name1[]
+    // tag::name[]
+    @Name("vendorName")
+    // end::name[]
     private String vendor;
 
     // tag::nonnull[]
     @NonNull
     // end::nonnull[]
-    // tag::name2[]
-    @Name("version")
-    // end::name2[]
     private String version;
 
     public JavaInfo(Properties systemProperties) {

--- a/finish/src/main/java/io/openliberty/guides/graphql/models/OperatingSystem.java
+++ b/finish/src/main/java/io/openliberty/guides/graphql/models/OperatingSystem.java
@@ -29,15 +29,12 @@ import org.eclipse.microprofile.graphql.Type;
 public class OperatingSystem {
 
     @NonNull
-    @Name("arch")
     private String arch;
     
     @NonNull
-    @Name("name")
     private String name;
     
     @NonNull
-    @Name("version")
     private String version;
     
     public OperatingSystem(Properties systemProperties) {

--- a/finish/src/main/java/io/openliberty/guides/graphql/models/OperatingSystem.java
+++ b/finish/src/main/java/io/openliberty/guides/graphql/models/OperatingSystem.java
@@ -36,7 +36,7 @@ public class OperatingSystem {
     @NonNull
     private String version;
 
-    public OperatingSystem(Properties systemProperties) {
+    public OperatingSystem(final Properties systemProperties) {
         this.arch = systemProperties.getProperty("os.arch");
         this.name = systemProperties.getProperty("os.name");
         this.version = systemProperties.getProperty("os.version");

--- a/finish/src/main/java/io/openliberty/guides/graphql/models/OperatingSystem.java
+++ b/finish/src/main/java/io/openliberty/guides/graphql/models/OperatingSystem.java
@@ -15,7 +15,6 @@ package io.openliberty.guides.graphql.models;
 import java.util.Properties;
 
 import org.eclipse.microprofile.graphql.Description;
-import org.eclipse.microprofile.graphql.Name;
 import org.eclipse.microprofile.graphql.NonNull;
 import org.eclipse.microprofile.graphql.Type;
 
@@ -30,27 +29,27 @@ public class OperatingSystem {
 
     @NonNull
     private String arch;
-    
+
     @NonNull
     private String name;
-    
+
     @NonNull
     private String version;
-    
+
     public OperatingSystem(Properties systemProperties) {
         this.arch = systemProperties.getProperty("os.arch");
         this.name = systemProperties.getProperty("os.name");
         this.version = systemProperties.getProperty("os.version");
     }
-    
+
     public String getArch() {
         return this.arch;
     }
-    
+
     public String getName() {
         return this.name;
     }
-    
+
     public String getVersion() {
         return this.version;
     }

--- a/finish/src/main/java/io/openliberty/guides/graphql/models/SystemInfo.java
+++ b/finish/src/main/java/io/openliberty/guides/graphql/models/SystemInfo.java
@@ -36,7 +36,7 @@ public class SystemInfo {
         super();
     }
 
-    public SystemInfo(Properties systemProperties) {
+    public SystemInfo(final Properties systemProperties) {
         this.username = systemProperties.getProperty("user.name");
         this.timezone = systemProperties.getProperty("user.timezone");
         this.note = systemProperties.getProperty("note");

--- a/finish/src/main/java/io/openliberty/guides/graphql/models/SystemInfo.java
+++ b/finish/src/main/java/io/openliberty/guides/graphql/models/SystemInfo.java
@@ -15,9 +15,7 @@ package io.openliberty.guides.graphql.models;
 import java.util.Properties;
 
 import org.eclipse.microprofile.graphql.Description;
-import org.eclipse.microprofile.graphql.Name;
 import org.eclipse.microprofile.graphql.NonNull;
-import org.eclipse.microprofile.graphql.Source;
 import org.eclipse.microprofile.graphql.Type;
 
 // tag::type[]
@@ -37,7 +35,7 @@ public class SystemInfo {
     public SystemInfo() {
         super();
     }
-    
+
     public SystemInfo(Properties systemProperties) {
         this.username = systemProperties.getProperty("user.name");
         this.timezone = systemProperties.getProperty("user.timezone");

--- a/finish/src/main/java/io/openliberty/guides/graphql/models/SystemInfo.java
+++ b/finish/src/main/java/io/openliberty/guides/graphql/models/SystemInfo.java
@@ -27,14 +27,11 @@ import org.eclipse.microprofile.graphql.Type;
 // tag::class[]
 public class SystemInfo {
 
-    @Name("timezone")
     private String timezone;
 
     @NonNull
-    @Name("username")
     private String username;
 
-    @Name("note")
     private String note;
 
     public SystemInfo() {

--- a/finish/src/test/java/io/openliberty/guides/graphql/SystemIT.java
+++ b/finish/src/test/java/io/openliberty/guides/graphql/SystemIT.java
@@ -35,17 +35,17 @@ import org.junit.jupiter.api.TestMethodOrder;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class SystemIT {
-    
-    private static String URL;
-    
+
+    private static String url;
+
     @BeforeAll
     public static void setUp() {
         // tag::client[]
         String port = System.getProperty("http.port");
-        URL = "http://localhost:" + port + "/graphql";
+        url = "http://localhost:" + port + "/graphql";
         // end::client[]
     }
-    
+
     // tag::test1[]
     @Test
     // end::test1[]
@@ -53,26 +53,26 @@ public class SystemIT {
     // tag::testGet[]
     public void testGetSystem() throws ClientProtocolException, IOException {
         HttpClient httpClient = HttpClients.createDefault();
-        HttpPost post = new HttpPost(URL);
+        HttpPost post = new HttpPost(url);
         StringEntity entity = new StringEntity(
-                "{ \"query\": " + 
-                    "\"query { " + 
-                        "system { " + 
-                            "username timezone " +
-                            "java { version vendorName } " +
-                            "operatingSystem {arch name version} " +
-                        "} " +
-                    "}" +
-                "\"}", 
+                "{ \"query\": "
+                    + "\"query { "
+                        + "system { "
+                            + "username timezone "
+                            + "java { version vendorName } "
+                            + "operatingSystem {arch name version} "
+                        + "} "
+                    + "}"
+                + "\"}",
                 ContentType.create("application/json", Consts.UTF_8));
         post.setEntity(entity);
         HttpResponse response = httpClient.execute(post);
         assertNotNull(response.getEntity(), "No system info received");
-        assertFalse(EntityUtils.toString(response.getEntity()).contains("error"), 
+        assertFalse(EntityUtils.toString(response.getEntity()).contains("error"),
                 "Response has errors");
     }
     // end::testGet[]
-    
+
     // tag::test2[]
     @Test
     // end::test2[]
@@ -81,23 +81,22 @@ public class SystemIT {
     public void testEditNote() throws ClientProtocolException, IOException {
         String expectedNote = "Time: " + System.currentTimeMillis();
         HttpClient httpClient = HttpClients.createDefault();
-        HttpPost mutation = new HttpPost(URL);
+        HttpPost mutation = new HttpPost(url);
         StringEntity mutationBody = new StringEntity(
-                "{ \"query\": " +
-                    "\"mutation ($noteArg: String!) {" +
-                        "editNote(note: $noteArg)" +
-                    "}\", " +
-                    "\"variables\": {\"" +
-                        "noteArg\": \""+ expectedNote +"\"" +
-                    "}" +
-                "}", 
-                ContentType.create("application/json", 
-                Consts.UTF_8));
+                "{ \"query\": "
+                    + "\"mutation ($noteArg: String!) {"
+                        + "editNote(note: $noteArg)"
+                    + "}\", "
+                    + "\"variables\": {\""
+                        + "noteArg\": \"" + expectedNote + "\""
+                    + "}"
+                + "}",
+                ContentType.create("application/json", Consts.UTF_8));
         mutation.setEntity(mutationBody);
         HttpResponse mutateResponse = httpClient.execute(mutation);
         assertNotNull(mutateResponse.getEntity());
-        
-        HttpPost query = new HttpPost(URL);
+
+        HttpPost query = new HttpPost(url);
         StringEntity queryBody = new StringEntity(
                 "{ \"query\": " + 
                     "\"query { " + 
@@ -106,12 +105,13 @@ public class SystemIT {
                         "} " + 
                     "}" +
                 "\"}", 
-                ContentType.create("application/json", 
+                ContentType.create("application/json",
                 Consts.UTF_8));
         query.setEntity(queryBody);
         HttpResponse queryResponse = httpClient.execute(query);
         assertNotNull(queryResponse.getEntity(), "No system info received");
-        assertTrue(EntityUtils.toString(queryResponse.getEntity()).contains(expectedNote), 
+        assertTrue(
+                EntityUtils.toString(queryResponse.getEntity()).contains(expectedNote),
                 "Response does not contain expected note");
     }
     // end::testEdit[]

--- a/finish/src/test/java/io/openliberty/guides/graphql/SystemIT.java
+++ b/finish/src/test/java/io/openliberty/guides/graphql/SystemIT.java
@@ -98,13 +98,13 @@ public class SystemIT {
 
         HttpPost query = new HttpPost(url);
         StringEntity queryBody = new StringEntity(
-                "{ \"query\": " + 
-                    "\"query { " + 
-                        "system { " + 
-                            "note" + 
-                        "} " + 
-                    "}" +
-                "\"}", 
+                "{ \"query\": "
+                    + "\"query { "
+                        + "system { "
+                            + "note"
+                        + "} "
+                    + "}"
+                + "\"}",
                 ContentType.create("application/json",
                 Consts.UTF_8));
         query.setEntity(queryBody);

--- a/finish/src/test/java/io/openliberty/guides/graphql/SystemIT.java
+++ b/finish/src/test/java/io/openliberty/guides/graphql/SystemIT.java
@@ -59,7 +59,7 @@ public class SystemIT {
                     "\"query { " + 
                         "system { " + 
                             "username timezone " +
-                            "java { version vendor } " +
+                            "java { version vendorName } " +
                             "operatingSystem {arch name version} " +
                         "} " +
                     "}" +

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>3.3</version>
+            <version>4.0.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>


### PR DESCRIPTION
Addressing comments from Slack:

- [x] I think POST is used too much in the "What you'll learn" section.  It should be possible to use a GET request too (although that usage is uncommon), but I would suggest just using it once and then referring to "POST requests" simply as "requests".  I'd also suggest mentioning HTTP some where in the first section - maybe this sentence:  Unlike REST APIs, POST requests going to a GraphQL service all go to a single HTTP endpoint.
- [x] In the Creating GraphQL object types section, could you mention that the `@Name("someName")` annotation is only necessary if you the user wants to use a name other than the field name?  i.e. `@Name("vendor")` private String vendor; is redundant (it's still ok, just unneeded code - a better use would be if the text inside the annotation didn't match the field - like `@Name("vendorName")` private String vendor; )
- [x] For this sentence, "Each resolver function has an `@Description` annotation, which provides a description to be used for the schema." I think it might be good to mention that the `@Description` annotation is not required, but is a good practice to use.
- [x] Similar to my first bullet, I think "Queries made through GraphiQL will be the same as queries made through POST requests." in the "Running the application" section should be changed to: "Queries made through GraphiQL will be the same as queries made through HTTP requests."
- [x] This is a nit, but in the example, could we either use an IBM JDK or not print the vendor - I think some IBMers might not like to see `"vendor": "Oracle Corporation"`, in our docs.